### PR TITLE
Added IPythonModule.DependentPackageVersion property

### DIFF
--- a/PythonNETExtensions/Modules/IPythonModule.cs
+++ b/PythonNETExtensions/Modules/IPythonModule.cs
@@ -12,6 +12,8 @@ namespace PythonNETExtensions.Modules
     public interface IPythonModule<PyModuleT>: IPythonModuleBase where PyModuleT: struct, IPythonModule<PyModuleT>
     {
         public static abstract string DependentPackage { get; }
+
+        public static virtual string? DependentPackageVersion => null;
         
         public static abstract string ModuleName { get; }
 

--- a/SampleCode/Program.cs
+++ b/SampleCode/Program.cs
@@ -17,6 +17,9 @@ namespace SampleCode
         private struct Numpy: IPythonModule<Numpy>
         {
             public static string DependentPackage => "numpy";
+            
+            static string IPythonModule<Numpy>.DependentPackageVersion => "2.2.0";
+            
             public static string ModuleName => DependentPackage;
         }
 

--- a/SampleCode/SampleCode.csproj
+++ b/SampleCode/SampleCode.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This enables for specifying pip version of a dependent package.

Example:

```cs
private struct Numpy: IPythonModule<Numpy>
{
    public static string DependentPackage => "numpy";

    static string IPythonModule<Numpy>.DependentPackageVersion => "2.2.0";

    public static string ModuleName => DependentPackage;
}
```